### PR TITLE
Add collection options

### DIFF
--- a/lib/heroics/client_generator.rb
+++ b/lib/heroics/client_generator.rb
@@ -29,8 +29,7 @@ module Heroics
       resource_schema.links.each do |link_schema|
         links << GeneratorLink.new(link_schema.name.gsub('-', '_'),
                                    link_schema.description,
-                                   link_schema.parameter_details,
-                                   link_schema.needs_request_body?)
+                                   link_schema.parameter_details)
       end
       resources << GeneratorResource.new(resource_schema.name.gsub('-', '_'),
                                          resource_schema.description,
@@ -66,20 +65,22 @@ module Heroics
   # A representation of a link for use when generating source code in the
   # template.
   class GeneratorLink
-    attr_reader :name, :description, :parameters, :takes_body
+    attr_reader :name, :description, :parameters
 
-    def initialize(name, description, parameters, takes_body)
+    def initialize(name, description, parameters)
       @name = name
       @description = description
       @parameters = parameters
-      if takes_body
-        parameters << BodyParameter.new
-      end
+    end
+
+    # List of parameters for the method signature
+    def signatures
+      @parameters.map { |info| info.signature }.join(', ')
     end
 
     # The list of parameters to render in generated source code for the method
     # signature for the link.
-    def parameter_names
+    def parameter_list
       @parameters.map { |info| info.name }.join(', ')
     end
   end
@@ -92,15 +93,5 @@ module Heroics
       text.sub!(replace) { |match| match.upcase }
     end
     text
-  end
-
-  # A representation of a body parameter.
-  class BodyParameter
-    attr_reader :name, :description
-
-    def initialize
-      @name = 'body'
-      @description = 'the object to pass as the request payload'
-    end
   end
 end

--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -358,11 +358,11 @@ module Heroics
 
   # The base parameter class
   class BaseParameter
-    attr_reader :name, :description
+    attr_reader :resource_name, :name, :description
 
     # This is the used for generating the function signature
     def signature
-      @name
+      [@resource_name, @name].compact.join("_")
     end
 
     # A pretty representation of a parameter instance
@@ -373,8 +373,6 @@ module Heroics
 
   # A representation of a parameter.
   class Parameter < BaseParameter
-    attr_reader :resource_name
-
     def initialize(resource_name, name, description)
       @resource_name = resource_name
       @name = name
@@ -410,7 +408,7 @@ module Heroics
 
   # A representation of a set of parameters.
   class ParameterChoice < BaseParameter
-    attr_reader :resource_name, :parameters
+    attr_reader :parameters
 
     def initialize(resource_name, parameters)
       @resource_name = resource_name
@@ -427,6 +425,10 @@ module Heroics
           "#{@resource_name}_#{parameter.name}"
         end
       end.join('_or_')
+    end
+
+    def signature
+      name
     end
 
     # A description created by merging individual parameter descriptions.

--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -117,8 +117,8 @@ module <%= @module_name %>
     # @param <%= parameter.name %>: <%= parameter.description %>
     <% end %>
     <% end %>
-    def <%= link.name %>(<%= link.parameter_names %>)
-      @client.<%= resource.name %>.<%= link.name %>(<%= link.parameter_names %>)
+    def <%= link.name %>(<%= link.signatures %>)
+      @client.<%= resource.name %>.<%= link.name %>(<%= link.parameter_list %>)
     end
     <% end %>
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -184,6 +184,11 @@ SAMPLE_SCHEMA = {
       'properties' => {},
 
       'links' => [
+        {'description' => 'Create another resource',
+         'href'        => '/another-resource',
+         'method'      => 'POST',
+         'rel'         => 'self',
+         'title'       => 'Create'},
         {'description' => 'Show all sample resources',
          'href'        => '/another-resource',
          'method'      => 'GET',

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -121,6 +121,7 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
     parameters = link.parameter_details
     parameter = parameters[0]
     assert_equal('collection_options', parameter.name)
+    assert_equal('collection_options = {}', parameter.signature)
     assert_equal('additional collection options to pass with the request', parameter.description)
   end
 
@@ -133,6 +134,7 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
     assert_equal(1, parameters.length)
     parameter = parameters[0]
     assert_equal('resource_uuid_field', parameter.name)
+    assert_equal('resource_uuid_field', parameter.signature)
     assert_equal('A sample UUID field', parameter.description)
   end
 
@@ -146,6 +148,7 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
     assert_equal(1, parameters.length)
     parameter = parameters[0]
     assert_equal('resource_uuid_field_or_resource_email_field', parameter.name)
+    assert_equal('resource_uuid_field_or_resource_email_field', parameter.signature)
     assert_equal('A sample UUID field or A sample email address field',
                  parameter.description)
   end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -109,8 +109,19 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
   # require parameters.
   def test_parameter_details_without_parameters
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
-    link = schema.resource('resource').link('list')
+    link = schema.resource('another-resource').link('create')
     assert_equal([], link.parameter_details)
+  end 
+
+  # LinkSchema.parameter_details returns an options parameter if the
+  # link is for a collection of instances.
+  def test_parameter_details_with_collection_options_parameter
+    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
+    link = schema.resource('resource').link('list')
+    parameters = link.parameter_details
+    parameter = parameters[0]
+    assert_equal('collection_options', parameter.name)
+    assert_equal('additional collection options to pass with the request', parameter.description)
   end
 
   # LinkSchema.parameter_details returns an array of Parameter with information


### PR DESCRIPTION
Currently heroics doesn't support passing additional parameters for
links that return collections. Having the ability to pass collection options are
useful a number of reasons. Mainly, for my use-case I want to use it for
pagination, however, I can see other JSON API's using it for filtering
collections.

This change works by inspecting the `rel` attribute on the link schema
to determine if the link returns a collection.  If `"rel"` contains the value
`instances` this change will add an additional parameter to the function
signature.

Here is an example of the output from the Heroics client generator using
this pull request:

```
# Show all sample resources
#
# @param collection_options: additional collection options to pass with the request
def list(collection_options = {})
  @client.another_resource.list(collection_options)
end
```

I think this is a useful feature, hopefully it can make it upstream :)
Please let me know what you think.
