### PR TITLE
Don't force dasherized resource names

### DIFF
--- a/lib/heroics/client.rb
+++ b/lib/heroics/client.rb
@@ -17,8 +17,7 @@ module Heroics
     # @raise [NoMethodError] Raised if the name doesn't match a known resource.
     # @return [Resource] The resource matching the name.
     def method_missing(name)
-      name = name.to_s.gsub('_', '-')
-      resource = @resources[name]
+      resource = @resources[name.to_s]
       if resource.nil?
         raise NoMethodError.new("undefined method `#{name}' for #{to_s}")
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -43,27 +43,6 @@ class ClientTest < MiniTest::Unit::TestCase
     end
     assert_equal('Hello, world!', client.resource.link)
   end
-
-  # Client converts underscores in resource method names to dashes to match
-  # names specified in the schema.
-  def test_resource_with_dashed_name
-    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
-    link = Heroics::Link.new('https://username:secret@example.com',
-                             schema.resource('another-resource').link('list'))
-    resource = Heroics::Resource.new({'link' => link})
-    client = Heroics::Client.new({'another-resource' => resource},
-                                 'http://example.com')
-    Excon.stub(method: :get) do |request|
-      assert_equal('Basic dXNlcm5hbWU6c2VjcmV0',
-                   request[:headers]['Authorization'])
-      assert_equal('example.com', request[:host])
-      assert_equal(443, request[:port])
-      assert_equal('/another-resource', request[:path])
-      Excon.stubs.pop
-      {status: 200, body: 'Hello, world!'}
-    end
-    assert_equal('Hello, world!', client.another_resource.link)
-  end
 end
 
 class ClientFromSchemaTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
We don't use dasherized resource names in our JSON Schema. For example, Heroku defines schemata like `account-feature`. When its invoked from the Ruby client it converts `account_feature` to `account-feature` when it looks up the JSON Schema to see if the API method exists.
